### PR TITLE
docs: generate processor docs from docstring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ doc: doc-build  ## Build and open the docs
 .PHONY: doc
 
 doc-build:  ## Build the docs
-	rm -r $(DOC_OUTPUT_DIR)
+	rm -rf $(DOC_OUTPUT_DIR)
 	poetry run pandoc --from=markdown --to=rst --output=$(DOC_SOURCE_DIR)/tutorial.rst docs/tutorial.md
 	poetry run pandoc --from=markdown --to=rst --output=$(DOC_SOURCE_DIR)/changelog.rst CHANGELOG.md
 	poetry run sphinx-build -b html $(DOC_SOURCE_DIR) $(DOC_OUTPUT_DIR)

--- a/avatars/processors/expected_mean.py
+++ b/avatars/processors/expected_mean.py
@@ -63,7 +63,7 @@ class ExpectedMeanProcessor:
                 self.nogroup_value for i in range(len(working))
             ]
         cols = self.groupby_variables + self.target_variables
-        self.properties_df = get_distribution_data(
+        self.properties_df = _get_distribution_data(
             df=working[cols],
             target_variables=self.target_variables,
             groupby_variables=self.groupby_variables,
@@ -90,7 +90,7 @@ class ExpectedMeanProcessor:
             # if no groupby, create a one-modality temporary variable
             dest[self.nogroup_name] = [self.nogroup_value] * len(dest)
         cols = self.groupby_variables + self.target_variables
-        current_properties_df = get_distribution_data(
+        current_properties_df = _get_distribution_data(
             df=dest[cols],
             target_variables=self.target_variables,
             groupby_variables=self.groupby_variables,
@@ -138,7 +138,7 @@ class ExpectedMeanProcessor:
         return dest
 
 
-def get_distribution_data(
+def _get_distribution_data(
     df: pd.DataFrame,
     target_variables: List[str],
     groupby_variables: List[str],

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,6 +16,7 @@ Table of contents
    Tutorial <tutorial>
    Client <client_and_api>
    Models <models>
+   Processors <processors>
    Changelog <changelog>
 
 Our main docs are at https://docs.octopize.io/

--- a/doc/source/processors.rst
+++ b/doc/source/processors.rst
@@ -1,0 +1,32 @@
+Processors
+==========
+
+
+These processors are used to process data before and after avatarization.
+
+Definitions
+-----------
+
+.. automodule:: avatars.processors.expected_mean
+   :members:
+   :special-members: __init__
+
+.. automodule:: avatars.processors.group_modalities
+   :members:
+   :special-members: __init__
+
+.. automodule:: avatars.processors.perturbation
+   :members:
+   :special-members: __init__
+
+.. automodule:: avatars.processors.proportions
+   :members:
+   :special-members: __init__
+
+.. automodule:: avatars.processors.relative_difference
+   :members:
+   :special-members: __init__
+
+.. automodule:: avatars.processors.relative_range
+   :members:
+   :special-members: __init__


### PR DESCRIPTION
PR to generate docs from the processor docstrings using Sphinx.

Currently, everytime some adds a new processor, they need to be added to the `processors.rst`.
Automating this could be of value, though `test_*` files, `lib` and `conftest` need to be excluded. 

Example output:

![image](https://user-images.githubusercontent.com/25140344/207404139-7cf63000-4f50-4611-b250-2df67116c81b.png)
