### PR TITLE
feat(doc): add main section to docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,12 @@ We use `sphinx` to build our documentation, along with a few extensions.
 
   This is used to generate documentation from `pydantic` models which come with useful information such as constrained values and a docstring per variable.
 
+## Versioning
+
+We want to show the documentation of all the different Python client versions. We thus use `sphinx-multiversion` to generate one version of the documentation for each release.
+
+To show a sidebar to the user, we override the `ethical-ads.html` page that serves as a sidebar when deploying on ReadTheDocs. As we are only deploying on Github Pages, we can safely override this.
+
 ## Build process
 
 Use `make doc-build` to build the documentation. Be on the lookout for errors during the build process, as `sphinx-multiversion` will not stop the build process on errors.

--- a/doc/source/_templates/sidebar/ethical-ads.html
+++ b/doc/source/_templates/sidebar/ethical-ads.html
@@ -2,17 +2,16 @@
   This file is only used on ReadTheDocs. -->
 {% if versions %}
 <div class="sidebar-tree">
-{%- if versions.tags %}
   <p class="caption" role="heading">
     <span class="caption-text">{{ _('Versions') }}</span>
   </p>
   <ul>
-    {%- for item in versions.tags| sort(reverse = True) %}
+  <!-- https://holzhaus.github.io/sphinx-multiversion/master/templates.html#list-branches-and-tags-separately -->
+    {%- for item in versions| sort(reverse = True) %}
     <li class="toctree-l1">
       <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
     </li>
     {%- endfor %}
   </ul>
-  {%- endif %}
 </div>
 {% endif %}

--- a/doc/source/_templates/sidebar/ethical-ads.html
+++ b/doc/source/_templates/sidebar/ethical-ads.html
@@ -1,5 +1,5 @@
 <!-- We are overriding the ethical-ads.html file form the furo theme to display versions.
-  This file is only used on ReadTheDocs. -->
+  This file is only used on ReadTheDocs. As we are not using ReadTheDocs, we can override it no problem. -->
 {% if versions %}
 <div class="sidebar-tree">
   <p class="caption" role="heading">
@@ -7,7 +7,12 @@
   </p>
   <ul>
   <!-- https://holzhaus.github.io/sphinx-multiversion/master/templates.html#list-branches-and-tags-separately -->
-    {%- for item in versions| sort(reverse = True) %}
+    {%- for item in versions.branches %}
+    <li class="toctree-l1">
+      <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
+    </li>
+    {%- endfor %}
+    {%- for item in versions.tags| sort(reverse = True) %}
     <li class="toctree-l1">
       <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
     </li>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,7 +82,7 @@ smv_branch_whitelist = f"^(main|{current_branch.strip()})$"
 # Add the pattern for which you want the releases to appear.
 smv_released_pattern = r"^(refs/tags/.*|main$)"
 
-# See [doc/README.md](doc/README.md) for explanation on the tag
+# See [doc/README.md](doc/README.md) for explanation on the regex.
 smv_tag_whitelist = r"^(0\.[0-5].[0-9]+|0.6.0)$"
 
 # -------------------------------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -80,7 +80,7 @@ current_branch, _ = proc.communicate()
 smv_branch_whitelist = f"^(main|{current_branch.strip()})$"
 # Tags define a release, which are the ones that show up on the sidebar.
 # Add the pattern for which you want the releases to appear.
-smv_released_pattern = r"^refs/tags/.*$"
+smv_released_pattern = r"^(refs/tags/.*|main$)"
 
 # See [doc/README.md](doc/README.md) for explanation on the tag
 smv_tag_whitelist = r"^(0\.[0-5].[0-9]+|0.6.0)$"


### PR DESCRIPTION
NOTE: Because of how we are running `sphinx-multiversion` twice due to the 2 separate pydantic versions, it cannot correctly generate the sidebar with all the versions. Each run shows the sidebar with all the versions that were seen during that particular run.

Currently, when pushing a modifications to the doc, without creating a new client release (to be specific, creating a new tag), the modifications will not be shown on the website.

That is because it currently only takes the version of the docs associated to the latest release.

This PR adds a section to be able to show the latest version of `main` (the current branch will be gone when building on main):

![image](https://user-images.githubusercontent.com/25140344/227586833-93665113-5c18-4c68-9f0b-dd96b5e3313b.png)

TODO:

- [ ] Modify GitHub action to build it correctly.
