### PR TITLE
fix: add keep_record_order to InterRecordRangeDifferenceProcessor

### DIFF
--- a/avatars/processors/inter_record_range_difference.py
+++ b/avatars/processors/inter_record_range_difference.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pandas as pd
 
 

--- a/avatars/processors/inter_record_range_difference_test.py
+++ b/avatars/processors/inter_record_range_difference_test.py
@@ -51,7 +51,7 @@ def test_preprocess(
     assert_frame_equal(processed_df, preprocessed_df_with_cumulated, check_dtype=False)
 
 
-def test_postprocess(
+def test_postprocess_with_keep_order(
     df_with_cumulated: pd.DataFrame, preprocessed_df_with_cumulated: pd.DataFrame
 ) -> None:
     "Verify that the postprocess is correct."
@@ -63,13 +63,49 @@ def test_postprocess(
         new_first_variable="first_value",
         new_range_variable="range_value",
         new_difference_variable="value_difference",
+        keep_record_order=True,
     )
 
     postprocessed_df = processor.postprocess(
         df_with_cumulated, preprocessed_df_with_cumulated
     )
 
+    # records should be decoded following order given by id_variable and sort_by_variable
     assert_frame_equal(postprocessed_df, df_with_cumulated, check_dtype=False)
+
+
+def test_postprocess_without_keep_order(
+    df_with_cumulated: pd.DataFrame, preprocessed_df_with_cumulated: pd.DataFrame
+) -> None:
+    "Verify that the postprocess without keep_record_order is correct."
+    processor = InterRecordRangeDifferenceProcessor(
+        id_variable="id",
+        target_start_variable="start",
+        target_end_variable="end",
+        sort_by_variable="start",
+        new_first_variable="first_value",
+        new_range_variable="range_value",
+        new_difference_variable="value_difference",
+        keep_record_order=False,
+    )
+    # make indices of processed_df different than those of df_with_cumulated
+    preprocessed_df_with_cumulated.index = range(
+        10, 10 + len(preprocessed_df_with_cumulated), 1
+    )
+
+    postprocessed_df = processor.postprocess(
+        df_with_cumulated, preprocessed_df_with_cumulated
+    ).reset_index(drop=True)
+
+    # records should be decoded following row order
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 1, 1, 2, 2],
+            "start": [6, 12, 7, 12, 16, 23],
+            "end": [7, 16, 8, 15, 18, 24],
+        }
+    )
+    assert_frame_equal(postprocessed_df, expected, check_dtype=False)
 
 
 @pytest.mark.parametrize(
@@ -78,7 +114,7 @@ def test_postprocess(
 )
 def test_preprocess_raises_error_when_wrong_var(
     df_with_cumulated: pd.DataFrame, argument_name: str
-):
+) -> None:
     # all the correct arguments, that should pass without errors
     arguments = dict(
         id_variable="id",
@@ -88,12 +124,13 @@ def test_preprocess_raises_error_when_wrong_var(
         new_first_variable="first_value",
         new_range_variable="range_value",
         new_difference_variable="value_difference",
+        keep_record_order=True,
     )
 
     # assign a wrong value to one of the argument
     arguments[argument_name] = "wrong_value"
 
-    processor = InterRecordRangeDifferenceProcessor(**arguments)
+    processor = InterRecordRangeDifferenceProcessor(**arguments)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="Expected valid variable names for"):
         processor.preprocess(df_with_cumulated)
@@ -105,7 +142,7 @@ def test_preprocess_raises_error_when_wrong_var(
 )
 def test_preprocess_raises_error_when_missing_values(
     df_with_cumulated: pd.DataFrame, argument_name: str
-):
+) -> None:
     # all the correct arguments
     arguments = dict(
         id_variable="id",
@@ -119,7 +156,7 @@ def test_preprocess_raises_error_when_missing_values(
 
     # add a missing value to one of the argument
     df_with_cumulated.loc[0, arguments[argument_name]] = np.nan
-    processor = InterRecordRangeDifferenceProcessor(**arguments)
+    processor = InterRecordRangeDifferenceProcessor(**arguments)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="Expected no missing values for"):
         processor.preprocess(df_with_cumulated)
@@ -138,7 +175,7 @@ def test_postprocess_raises_error_when_wrong_var(
     df_with_cumulated: pd.DataFrame,
     preprocessed_df_with_cumulated: pd.DataFrame,
     argument_name: str,
-):
+) -> None:
     # all the correct arguments, that should pass without errors
     arguments = dict(
         id_variable="id",
@@ -153,7 +190,7 @@ def test_postprocess_raises_error_when_wrong_var(
     # assign a wrong value to one of the argument
     arguments[argument_name] = "wrong_value"
 
-    processor = InterRecordRangeDifferenceProcessor(**arguments)
+    processor = InterRecordRangeDifferenceProcessor(**arguments)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="Expected valid variable names for"):
         processor.postprocess(df_with_cumulated, preprocessed_df_with_cumulated)
@@ -172,7 +209,7 @@ def test_postprocess_raises_error_when_missing_values(
     df_with_cumulated: pd.DataFrame,
     preprocessed_df_with_cumulated: pd.DataFrame,
     argument_name: str,
-):
+) -> None:
     # all the correct arguments
     arguments = dict(
         id_variable="id",
@@ -186,7 +223,33 @@ def test_postprocess_raises_error_when_missing_values(
 
     # add a missing value to one of the argument
     preprocessed_df_with_cumulated.loc[0, arguments[argument_name]] = np.nan
-    processor = InterRecordRangeDifferenceProcessor(**arguments)
+    processor = InterRecordRangeDifferenceProcessor(**arguments)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="Expected no missing values for"):
         processor.postprocess(df_with_cumulated, preprocessed_df_with_cumulated)
+
+
+def test_postprocess_raises_error_with_keep_order_and_different_indices(
+    df_with_cumulated: pd.DataFrame,
+) -> None:
+
+    processor = InterRecordRangeDifferenceProcessor(
+        id_variable="id",
+        target_start_variable="start",
+        target_end_variable="end",
+        sort_by_variable="start",
+        new_first_variable="first_value",
+        new_range_variable="range_value",
+        new_difference_variable="value_difference",
+        keep_record_order=True,
+    )
+
+    processed_df = processor.preprocess(df_with_cumulated)
+    # make indices of processed_df different than those of df_with_cumulated
+    processed_df.index = range(10, 10 + len(processed_df), 1)
+
+    with pytest.raises(
+        ValueError,
+        match="Expected no missing values for `keep_record_order` to be `True`",
+    ):
+        processor.postprocess(df_with_cumulated, processed_df)


### PR DESCRIPTION
Solves https://github.com/octopize/avatar/issues/1189

With this PR, the processor can be used to postprocess a df that has a different size than the original one (a case that happens with hierarchical data, for example when an avatarized individual has more (or fewer) trips than the original) 