### PR TITLE
feat: add keep_order to InterRecordCumulatedDifferenceProcessor

### DIFF
--- a/avatars/processors/inter_record_cumulated_difference_test.py
+++ b/avatars/processors/inter_record_cumulated_difference_test.py
@@ -46,7 +46,7 @@ def test_preprocess(
     assert_frame_equal(processed_df, preprocessed_df_with_cumulated, check_dtype=False)
 
 
-def test_postprocess(
+def test_postprocess_with_keep_order(
     df_with_cumulated: pd.DataFrame, preprocessed_df_with_cumulated: pd.DataFrame
 ) -> None:
     "Verify that the postprocess is correct."
@@ -55,12 +55,44 @@ def test_postprocess(
         target_variable="value",
         new_first_variable_name="first_value",
         new_difference_variable_name="value_difference",
+        keep_record_order=True,
     )
 
     postprocessed_df = processor.postprocess(
         df_with_cumulated, preprocessed_df_with_cumulated
     )
     assert_frame_equal(postprocessed_df, df_with_cumulated, check_dtype=False)
+
+
+def test_postprocess_without_keep_order(
+    df_with_cumulated: pd.DataFrame, preprocessed_df_with_cumulated: pd.DataFrame
+) -> None:
+    "Verify that the postprocess is correct."
+    processor = InterRecordCumulatedDifferenceProcessor(
+        id_variable="id",
+        target_variable="value",
+        new_first_variable_name="first_value",
+        new_difference_variable_name="value_difference",
+        keep_record_order=False,
+    )
+
+    # make indices of processed_df different than those of df_with_cumulated
+    preprocessed_df_with_cumulated.index = range(
+        10, 10 + len(preprocessed_df_with_cumulated), 1
+    )
+
+    # records should be decoded following row order
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 1, 1, 2, 2],
+            "value": [1025, 20002, 1025, 1130, 20002, 20042],
+        }
+    )
+    postprocessed_df = processor.postprocess(
+        df_with_cumulated, preprocessed_df_with_cumulated
+    ).reset_index(drop=True)
+
+    assert_frame_equal(postprocessed_df, expected, check_dtype=False)
 
 
 def test_preprocess_raises_error_when_missing_ids(
@@ -224,3 +256,25 @@ def test_postprocess_raises_error_when_wrong_difference_var(
         ValueError, match="Expected a valid `new_difference_variable_name`"
     ):
         processor.postprocess(df_with_cumulated, preprocessed_df_with_cumulated)
+
+
+def test_postprocess_raises_error_with_keep_order_and_different_indices(
+    df_with_cumulated: pd.DataFrame,
+) -> None:
+    processor = InterRecordCumulatedDifferenceProcessor(
+        id_variable="id",
+        target_variable="value",
+        new_first_variable_name="first_value",
+        new_difference_variable_name="value_difference",
+        keep_record_order=True,
+    )
+
+    processed_df = processor.preprocess(df_with_cumulated)
+    # make indices of processed_df different than those of df_with_cumulated
+    processed_df.index = range(10, 10 + len(processed_df), 1)
+
+    with pytest.raises(
+        ValueError,
+        match="Expected `keep_record_order` to be `True` only if",
+    ):
+        processor.postprocess(df_with_cumulated, processed_df)


### PR DESCRIPTION
Similar to #62 but for `InterRecordCumulatedDifferenceProcessor`

With this PR, the processor can be used to postprocess a df that has a different size than the original one (a case that happens with hierarchical data, for example when an avatarized individual has more (or fewer) trips than the original)

Issue https://github.com/octopize/avatar/issues/1189 can be then be closed.