### PR TITLE
fix(processor): handling of extra columns at postprocess

### DIFF
--- a/avatars/processors/inter_record_bounded_range_difference.py
+++ b/avatars/processors/inter_record_bounded_range_difference.py
@@ -341,6 +341,6 @@ class InterRecordBoundedRangeDifferenceProcessor:
         common_cols = [c for c in source.columns if c in working.columns]
         other_cols = [c for c in working.columns if c not in source.columns]
         cols_order = common_cols + other_cols
-
         working = working[cols_order]
+
         return working

--- a/avatars/processors/inter_record_bounded_range_difference.py
+++ b/avatars/processors/inter_record_bounded_range_difference.py
@@ -322,6 +322,25 @@ class InterRecordBoundedRangeDifferenceProcessor:
             ].astype(int)
 
         working = working.sort_values(by=["original_order"])
-        working = working[source.columns]
 
+        # remove temp variables
+        working = working.drop(
+            columns=[
+                "increase",
+                "decrease",
+                self.new_difference_variable_name,
+                self.new_first_variable_name,
+                self.new_range_variable,
+            ]
+        )
+        working = working.drop(
+            columns=["range_increase", "range_decrease", "original_order"]
+        )
+
+        # order columns
+        common_cols = [c for c in source.columns if c in working.columns]
+        other_cols = [c for c in working.columns if c not in source.columns]
+        cols_order = common_cols + other_cols
+
+        working = working[cols_order]
         return working

--- a/avatars/processors/inter_record_bounded_range_difference.py
+++ b/avatars/processors/inter_record_bounded_range_difference.py
@@ -214,7 +214,7 @@ class InterRecordBoundedRangeDifferenceProcessor:
             + working["increase"] * working["relative_diff_to_ub"]
         )
 
-        # Remove temp variables
+        # Remove tmp variables
         working = working.drop(
             columns=[
                 "relative_diff_to_lb",
@@ -323,19 +323,18 @@ class InterRecordBoundedRangeDifferenceProcessor:
 
         working = working.sort_values(by=["original_order"])
 
-        # remove temp variables
-        working = working.drop(
-            columns=[
-                "increase",
-                "decrease",
-                self.new_difference_variable_name,
-                self.new_first_variable_name,
-                self.new_range_variable,
-            ]
-        )
-        working = working.drop(
-            columns=["range_increase", "range_decrease", "original_order"]
-        )
+        # remove tmp variables
+        columns_to_remove = [
+            "increase",
+            "decrease",
+            self.new_difference_variable_name,
+            self.new_first_variable_name,
+            self.new_range_variable,
+            "range_increase",
+            "range_decrease",
+            "original_order",
+        ]
+        working = working.drop(columns=columns_to_remove)
 
         # order columns
         common_cols = [c for c in source.columns if c in working.columns]

--- a/avatars/processors/inter_record_bounded_range_difference_test.py
+++ b/avatars/processors/inter_record_bounded_range_difference_test.py
@@ -175,12 +175,14 @@ def test_extra_columns_are_kept_at_postprocess(df: pd.DataFrame) -> None:
     preprocessed_df = processor.preprocess(df)
 
     # Add an extra variable (this would typically happen when preprocessing many variables)
-    preprocessed_df["extra_variable"] = preprocessed_df["a_range"]
+    preprocessed_df["extra_variable_1"] = preprocessed_df["a_range"]
+    df["extra_variable_2"] = df["a_s"]
 
     postprocessed_df = processor.postprocess(df, preprocessed_df)
 
-    print(df.columns.to_list() + ["extra_variable"])
-    print("postprocessed_df.columns: ", postprocessed_df.columns)
-    assert postprocessed_df.columns.tolist() == df.columns.to_list() + [
-        "extra_variable"
-    ]
+    # Post-process df should have the additional variables from dest but not the additional
+    # variables from source
+    should_have_columns = df.columns.to_list() + ["extra_variable_1"]
+    should_have_columns.remove("extra_variable_2")
+
+    assert postprocessed_df.columns.tolist() == should_have_columns

--- a/avatars/processors/inter_record_bounded_range_difference_test.py
+++ b/avatars/processors/inter_record_bounded_range_difference_test.py
@@ -157,3 +157,30 @@ def test_preprocess_raises_error_when_missing_values(df: pd.DataFrame) -> None:
         match="Expected no missing values for",
     ):
         processor.preprocess(df)
+
+
+def test_extra_columns_are_kept_at_postprocess(df: pd.DataFrame) -> None:
+    processor = InterRecordBoundedRangeDifferenceProcessor(
+        id_variable="id",
+        target_start_variable="a_s",
+        target_end_variable="a_e",
+        new_first_variable_name="a_s_first_val",
+        new_difference_variable_name="a_diff_to_bound",
+        new_range_variable="a_range",
+        sort_by_variable=None,
+        should_round_output=False,
+    )
+
+    # Pre-process
+    preprocessed_df = processor.preprocess(df)
+
+    # Add an extra variable (this would typically happen when preprocessing many variables)
+    preprocessed_df["extra_variable"] = preprocessed_df["a_range"]
+
+    postprocessed_df = processor.postprocess(df, preprocessed_df)
+
+    print(df.columns.to_list() + ["extra_variable"])
+    print("postprocessed_df.columns: ", postprocessed_df.columns)
+    assert postprocessed_df.columns.tolist() == df.columns.to_list() + [
+        "extra_variable"
+    ]


### PR DESCRIPTION
There was a problem when doing `working = working[source.columns]` at post-process as source can have more variables than working.
The error occured when using this processor within a processors loop. Problem should be fixed and a test is added to ensure extra variables in `source` or in `dest` are not causing problems.