### PR TITLE
test: verify error message with wrong base_url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
         exclude: \.(svg|json)
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 3.12.0
+    rev: v3.12.0
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/avatars/client_test.py
+++ b/avatars/client_test.py
@@ -48,6 +48,6 @@ def test_should_verify_ssl(mock_client: Any) -> None:
 def test_url_is_rejected_if_it_contains_quotes(base_url: str) -> None:
     # Note there is "quote" within the URL, usually an error related to system
     # env variable configuration.
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="must not contain quotes") as exc_info:
         api_client = ApiClient(base_url=base_url)
-    assert "must not contain quotes" in str(exc_info.value)
+

--- a/avatars/client_test.py
+++ b/avatars/client_test.py
@@ -37,3 +37,17 @@ def test_should_verify_ssl(mock_client: Any) -> None:
     # Override the call in the request() method
     do_request(api_client, should_verify_ssl=True)
     assert mock_client.call_args.kwargs["verify"] == True
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        '"https://test.com"',
+    ],
+)
+def test_url_is_rejected_if_it_contains_quotes(base_url: str) -> None:
+    # Note there is "quote" within the URL, usually an error related to system
+    # env variable configuration.
+    with pytest.raises(ValueError) as exc_info:
+        api_client = ApiClient(base_url=base_url)
+    assert "must not contain quotes" in str(exc_info.value)


### PR DESCRIPTION
Add a test to make sure the client does check for an usual error
(issue and PR on avatar.git)